### PR TITLE
Added sinatra-webfinger, reordered libraries page

### DIFF
--- a/libraries.md
+++ b/libraries.md
@@ -3,24 +3,18 @@ layout: default
 title: WebFinger Libraries
 ---
 
-## WebFinger Libraries ##
+## On the Server
 
-### Go ###
+Tools to add WebFinger data to your domain.
 
- - [ant0ine/go-webfinger](https://github.com/ant0ine/go-webfinger)
+* **Wordpress**: ['webfinger' plugin](http://wordpress.org/plugins/webfinger/)
+* **Sinatra**: [sinatra-webfinger](https://github.com/konklone/sinatra-webfinger)
 
-### JavaScript ###
+## From the Client
 
- - [silverbucket/webfinger.js](https://github.com/silverbucket/webfinger.js)
+Libraries for consuming WebFinger data.
 
-### Node.js ###
-
- - [e14n/webfinger](https://github.com/e14n/webfinger)
-
-### PHP ###
-
- - [PEAR/Net_WebFinger](http://pear.php.net/package/Net_WebFinger/)
-
-### Other ###
-
- - [WordPress plugin](http://wordpress.org/plugins/webfinger/)
+* **JavaScript**: [silverbucket/webfinger.js](https://github.com/silverbucket/webfinger.js)
+* **Node.js**: [e14n/webfinger](https://github.com/e14n/webfinger)
+* **Go**: [ant0ine/go-webfinger](https://github.com/ant0ine/go-webfinger)
+* **PHP**: [PEAR/Net_WebFinger](http://pear.php.net/package/Net_WebFinger/)


### PR DESCRIPTION
I added [sinatra-webfinger](https://github.com/konklone/sinatra-webfinger), and split the page up into client and server sections. I also restructured the layout a little bit to keep it more compact and readable.
