### PR TITLE
Added Aaron Parecki's gist of an Apache redirect

### DIFF
--- a/code.md
+++ b/code.md
@@ -7,6 +7,7 @@ title: WebFinger Code
 
 Tools to add WebFinger data to your domain.
 
+ - **Apache**: [Aaron Parecki's example](https://gist.github.com/aaronpk/5846789) of an `.htaccess` redirect to a static file.
  - **Jekyll**: [jekyll-webfinger](https://github.com/konklone/jekyll-webfinger)
  - **Sinatra**: [sinatra-webfinger](https://github.com/konklone/sinatra-webfinger)
  - **WordPress**: ['webfinger' plugin](http://wordpress.org/plugins/webfinger/)


### PR DESCRIPTION
This came up in [webfinger/client.webfinger.net#2](https://github.com/webfinger/client.webfinger.net/issues/2#issuecomment-26295853) - Aaron Parecki made a nice gist of using `.htaccess` and a static file to set up personal Webfinger support using Apache alone. It's not "code" exactly, but I think it belongs here among a suite of tools to make setting up Webfinger support easier.
