### PR TITLE
Fix utf8 in local dev environment

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{{ page.title }}</title>
+    <meta charset="utf-8" />
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans" />
     <link rel="stylesheet" href="/css/style.css" />
   </head>


### PR DESCRIPTION
UTF8 characters work fine on the deployment server, but in development (like when running `jekyll serve`) they're messed up without the `<meta>` tag.
