### PR TITLE
changed issues-link

### DIFF
--- a/community.md
+++ b/community.md
@@ -10,7 +10,7 @@ You can help making this site better! The source code is available on
 have an idea or found a bug][new-issue]!
 
 [github-repo]: https://github.com/webfinger/webfinger.net
-[new-issue]: https://github.com/webfinger/webfinger.net/issues/new
+[new-issue]: https://github.com/webfinger/webfinger.net/issues
 
 
 ### Mailing Lists ###


### PR DESCRIPTION
The "new" url throws a 404 on mobile devices (tested on iPhone)

Seems to be a result of GitHubs mobile view: https://github.com/blog/1559-github-s-on-your-phone
