### PR TITLE
added schemas for image urls

### DIFF
--- a/opensearch.xml
+++ b/opensearch.xml
@@ -5,7 +5,7 @@
   <Tags>webfinger</Tags>
   <Contact>https://webfinger.net/</Contact>
   <Url type="text/html" template="https://client.webfinger.net/lookup?resource={searchTerms}"/>
-  <Image height="64" width="64" type="image/png">//webfinger.net/images/WebFinger-64x64.png</Image>
-  <Image height="16" width="16" type="image/png">//webfinger.net/images/WebFinger-16x16.png</Image>
-  <Image height="16" width="16" type="image/vnd.microsoft.icon">//webfinger.net/images/WebFinger-16x16.ico</Image>
+  <Image height="64" width="64" type="image/png">https://webfinger.net/images/WebFinger-64x64.png</Image>
+  <Image height="16" width="16" type="image/png">https://webfinger.net/images/WebFinger-16x16.png</Image>
+  <Image height="16" width="16" type="image/vnd.microsoft.icon">https://webfinger.net/images/WebFinger-16x16.ico</Image>
 </OpenSearchDescription>


### PR DESCRIPTION
it seems that browsers doesn't support schema-less urls in open search
documents