### PR TITLE
updated specs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -6,4 +6,4 @@ title: "WebFinger Specifications"
 ## Specifications ##
 
 * WebFinger Spec: [rfc7033](https://tools.ietf.org/html/rfc7033)
-* The 'acct' URI Scheme Spec: [draft-ietf-appsawg-acct-uri](https://tools.ietf.org/html/draft-ietf-appsawg-acct-uri) (draft)
+* The 'acct' URI Scheme Spec: [rfc7565](https://tools.ietf.org/html/rfc7565)


### PR DESCRIPTION
The 'acct' URI Scheme Spec is now rfc7565