### PR TITLE
Spec text update on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,9 +16,9 @@ From [the official spec](https://tools.ietf.org/html/rfc7033):
 > is queried. The JSON object is referred to as the JSON Resource Descriptor
 > (JRD).
 >
-> For a person, the kinds of information that might be discoverable via
-> WebFinger include a personal profile address, identity service, telephone
+> For a person, the type of information that might be discoverable via
+> WebFinger includes a personal profile address, identity service, telephone
 > number, or preferred avatar.  For other entities on the Internet, a WebFinger
 > resource might return JRDs containing link relations that enable a client to
-> discover, for example, the that a printer can print in color on A4 paper, the
+> discover, for example, that a printer can print in color on A4 paper, the
 > physical location of a server, or other static information.


### PR DESCRIPTION
The original rfc7033 spec, evidently, contained an error ("for example,
the that a") which made me squint at this paragraph a bit. Looking at
the official spec on the IETF website, it seems like there were a couple
updates to the quote that currently appears on webfinger.net, this patch
updates the quote from the spec to its most recent version (even though
I think changing "include" to "includes" below is not grammatically
correct).