### PR TITLE
content: update description of rel values

### DIFF
--- a/content/rel/_index.md
+++ b/content/rel/_index.md
@@ -2,9 +2,28 @@
 title: "Link Relations"
 ---
 
-## Link Relations ##
+## Link Relations
 
-* [http://webfinger.net/rel/avatar](./avatar)
-* [http://webfinger.net/rel/profile-page](./profile-page)
+All WebFinger links have a `rel` property that identifies the type of the link relation.
+Values can be URIs or a [registered relation type](https://www.iana.org/assignments/link-relations/).
+Any valid rel value can be used in WebFinger links.
 
-See also: [existing rel values](http://microformats.org/wiki/existing-rel-values) on the Microformats Wiki.
+The following rel values have been defined in the webfinger.net namespace to address common WebFinger use cases.
+
+### `http://webfinger.net/rel/avatar` {#avatar}
+
+The link relation `http://webfinger.net/rel/avatar` identifies a person's
+avatar and may be in any standard image format (e.g., PNG, JPEG, GIF).
+
+### `http://webfinger.net/rel/profile-page` {#profile-page}
+
+The link relation `http://webfinger.net/rel/profile-page` identifies the main
+home/profile page that a human should visit when getting info about that
+webfinger account. It says nothing about the content-type (or microformats),
+but it's likely text/html if it's for users.
+
+## Additional references:
+
+* [WebFinger section 4.4.4.1](https://www.rfc-editor.org/rfc/rfc7033#section-4.4.4.1) defines the rel property
+* [Web Linking (RFC 8288)](https://www.rfc-editor.org/rfc/rfc8288.html) defines the Link Relation Type Registry and provides more detail on links in general.
+* The microformats.org wiki maintains a page of [existing rel values](https://microformats.org/wiki/existing-rel-values) used in the wild.

--- a/content/rel/avatar.md
+++ b/content/rel/avatar.md
@@ -1,8 +1,5 @@
 ---
 title: "Link Relation: http://webfinger.net/rel/avatar"
+layout: redirect
+redirect_url: /rel/#avatar
 ---
-
-## Link Relation: `http://webfinger.net/rel/avatar` ##
-
-The link relation `http://webfinger.net/rel/avatar` identifies a person's
-avatar and may be in any standard image format (e.g., PNG, JPEG, GIF).

--- a/content/rel/profile-page.md
+++ b/content/rel/profile-page.md
@@ -1,11 +1,5 @@
 ---
 title: "Link Relation: http://webfinger.net/rel/profile-page"
+layout: redirect
+redirect_url: /rel/#profile-page
 ---
-
-## Link Relation: `http://webfinger.net/rel/profile-page` ##
-
-The link relation `http://webfinger.net/rel/profile-page` identifies the main
-home/profile page that a human should visit when getting info about that
-webfinger account. It says nothing about the content-type (or microformats),
-but it's likely text/html if it's for users. But maybe it's just Flash, for
-instance.

--- a/layouts/_default/redirect.html
+++ b/layouts/_default/redirect.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="robots" content="noindex">
+    <meta http-equiv="refresh" content="0; url={{ .Params.redirect_url | relURL }}">
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
move webfinger.net rel values to the main rel page and redirect individual pages to there.  Say a little bit more about how rel values are used and link to the official IANA link relation registry.

Updates #31

/cc @pfefferle