### PR TITLE
Add `lang` attribute to `<html>` element

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{ end }}</title>
     <meta charset="utf-8" />

--- a/layouts/_default/redirect.html
+++ b/layouts/_default/redirect.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta name="robots" content="noindex">
     <meta http-equiv="refresh" content="0; url={{ .Params.redirect_url | relURL }}">


### PR DESCRIPTION
Improves accessibility for those using screen readers, as described by https://dequeuniversity.com/rules/axe/4.7/html-has-lang.