### PR TITLE
Add empty `alt` text to logo `<img>`

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,7 +15,7 @@
       <div>
         <div class="site-title">
           <a href="/">
-            <img src="/images/WebFinger.svg" id="logo" />
+            <img src="/images/WebFinger.svg" id="logo" alt=""/>
             <h1>WebFinger</h1>
           </a>
           <p id="tagline">simple discovery for the web</p>


### PR DESCRIPTION
The logo is purely decorative, and is described by the proceeding `<h1>` tag (i.e., "WebFinger"). Setting `alt` to an empty string, so screen readers ignore the `<img>`, as recommended by https://dequeuniversity.com/rules/axe/4.7/image-alt.