### PR TITLE
Explicitly set `width` and `height` attributes on `<img>` element

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -36,7 +36,6 @@ header {
   }
 
   #logo {
-    height: 75px;
     float: left;
     margin: 0 1em;
   }

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,7 +15,7 @@
       <div>
         <div class="site-title">
           <a href="/">
-            <img src="/images/WebFinger.svg" id="logo" alt=""/>
+            <img src="/images/WebFinger.svg" id="logo" alt="" width="49" height="75"/>
             <h1>WebFinger</h1>
           </a>
           <p id="tagline">simple discovery for the web</p>


### PR DESCRIPTION
Reduces layout shifts, as defined by https://web.dev/optimize-cls/?utm_source=lighthouse&utm_medium=lr#images-without-dimensions.