### PR TITLE
Add Carpal to implementation list

### DIFF
--- a/content/code.md
+++ b/content/code.md
@@ -15,6 +15,7 @@ Tools to add WebFinger data to your domain.
  - **Jekyll**: [jekyll-webfinger](https://github.com/konklone/jekyll-webfinger)
  - **Laravel** [laravel-webfinger](https://github.com/trovster/laravel-webfinger)
  - **Go** [go-finger](https://github.com/Maronato/go-finger)
+ - **Go**: [carpal](https://github.com/peeley/carpal) (also supports loading resources from LDAP)
  - **Sinatra**: [sinatra-webfinger](https://github.com/konklone/sinatra-webfinger)
  - **WordPress**: ['webfinger' plugin](https://wordpress.org/plugins/webfinger/)
 


### PR DESCRIPTION
Hello, I'm the author of a WebFinger server implementation called [Carpal](https://github.com/peeley/carpal). This PR adds Carpal to the list of server implementations.

I wasn't sure about how to mention it on the page, but a worthwhile feature of Carpal that may be of interest to potential WebFinger admins is its ability to fetch WebFinger resources from an LDAP directory. If the suggested text is inappropriate or could be improved, I'm happy to make changes.